### PR TITLE
Reduce function definitions starting with case to function overload

### DIFF
--- a/Main.elm
+++ b/Main.elm
@@ -76,6 +76,11 @@ test num =
         1 -> "cichocinski"
         number -> ("wende", number)
 
+add a b =
+    case a of
+        1 -> a
+        _ -> b
+
 """
 update : Msg -> String -> String
 update action model =

--- a/Main.elm
+++ b/Main.elm
@@ -69,6 +69,13 @@ otherOrigin =
 
 
 type T = Int | String
+
+test : Int -> String
+test num =
+    case num of
+        1 -> "cichocinski"
+        number -> ("wende", number)
+
 """
 update : Msg -> String -> String
 update action model =

--- a/index.html
+++ b/index.html
@@ -12414,8 +12414,8 @@ var _user$project$Compiler$getVariableName = function (e) {
 		return _elm_lang$core$Native_Utils.crashCase(
 			'Compiler',
 			{
-				start: {line: 357, column: 5},
-				end: {line: 359, column: 35}
+				start: {line: 361, column: 5},
+				end: {line: 363, column: 35}
 			},
 			_p0)('jeb');
 	}
@@ -12424,8 +12424,8 @@ var _user$project$Compiler$notImplemented = function (value) {
 	return _elm_lang$core$Native_Utils.crash(
 		'Compiler',
 		{
-			start: {line: 353, column: 5},
-			end: {line: 353, column: 16}
+			start: {line: 357, column: 5},
+			end: {line: 357, column: 16}
 		})(
 		A2(
 			_elm_lang$core$Basics_ops['++'],
@@ -12511,8 +12511,8 @@ var _user$project$Compiler$defOrDefp = F2(
 				return _elm_lang$core$Native_Utils.crashCase(
 					'Compiler',
 					{
-						start: {line: 140, column: 5},
-						end: {line: 148, column: 41}
+						start: {line: 144, column: 5},
+						end: {line: 152, column: 41}
 					},
 					_p3)('No such export');
 		}
@@ -12879,8 +12879,8 @@ var _user$project$Compiler$tupleOrFunction = F2(
 		return _elm_lang$core$Native_Utils.crashCase(
 			'Compiler',
 			{
-				start: {line: 303, column: 5},
-				end: {line: 328, column: 75}
+				start: {line: 307, column: 5},
+				end: {line: 332, column: 75}
 			},
 			_p17)(
 			A2(
@@ -12912,8 +12912,8 @@ var _user$project$Compiler$combineComas = function (e) {
 		return _elm_lang$core$Native_Utils.crashCase(
 			'Compiler',
 			{
-				start: {line: 363, column: 5},
-				end: {line: 368, column: 46}
+				start: {line: 367, column: 5},
+				end: {line: 372, column: 46}
 			},
 			_p19)(
 			_elm_lang$core$Basics$toString(_p19));
@@ -13237,35 +13237,42 @@ var _user$project$Compiler$elixirS = F2(
 								_p24._0,
 								_user$project$Compiler$typespec(_p24._1))));
 				case 'FunctionDeclaration':
-					var _p29 = _p24._0;
-					var _p28 = _p24._2;
-					var _p25 = _p28;
-					if (_p25.ctor === 'Case') {
-						return A3(
-							_elm_lang$core$List$foldr,
-							F2(
-								function (x, y) {
-									return A2(_elm_lang$core$Basics_ops['++'], x, y);
-								}),
-							'',
-							A2(
-								_elm_lang$core$List$map,
-								function (_p26) {
-									var _p27 = _p26;
-									return A4(
-										_user$project$Compiler$genElixirFunc,
-										c,
-										_p29,
-										{
-											ctor: '::',
-											_0: A2(_user$project$Compiler$elixirE, _p27._0, c.indent),
-											_1: {ctor: '[]'}
-										},
-										_p27._1);
-								},
-								A2(_elm_lang$core$Debug$log, 'expression', _p25._1)));
+					var _p30 = _p24._0;
+					var _p29 = _p24._2;
+					var _p28 = _p24._1;
+					if (_elm_lang$core$Native_Utils.cmp(
+						_elm_lang$core$List$length(_p28),
+						1) > 0) {
+						return A4(_user$project$Compiler$genElixirFunc, c, _p30, _p28, _p29);
 					} else {
-						return A4(_user$project$Compiler$genElixirFunc, c, _p29, _p24._1, _p28);
+						var _p25 = _p29;
+						if (_p25.ctor === 'Case') {
+							return A3(
+								_elm_lang$core$List$foldr,
+								F2(
+									function (x, y) {
+										return A2(_elm_lang$core$Basics_ops['++'], x, y);
+									}),
+								'',
+								A2(
+									_elm_lang$core$List$map,
+									function (_p26) {
+										var _p27 = _p26;
+										return A4(
+											_user$project$Compiler$genElixirFunc,
+											c,
+											_p30,
+											{
+												ctor: '::',
+												_0: A2(_user$project$Compiler$elixirE, _p27._0, c.indent),
+												_1: {ctor: '[]'}
+											},
+											_p27._1);
+									},
+									_p25._1));
+						} else {
+							return A4(_user$project$Compiler$genElixirFunc, c, _p30, _p28, _p29);
+						}
 					}
 				case 'Comment':
 					return A2(
@@ -13305,12 +13312,12 @@ var _user$project$Compiler$elixirS = F2(
 		return _user$project$Compiler$notImplemented(_p24);
 	});
 var _user$project$Compiler$tree = function (m) {
-	var _p30 = _brainrape$elm_ast$Ast$parse(m);
+	var _p31 = _brainrape$elm_ast$Ast$parse(m);
 	_v22_2:
 	do {
-		if (_p30.ctor === 'Ok') {
-			if ((_p30._0.ctor === '_Tuple3') && (_p30._0._2.ctor === '::')) {
-				var context = _user$project$Compiler$moduleStatement(_p30._0._2._0);
+		if (_p31.ctor === 'Ok') {
+			if ((_p31._0.ctor === '_Tuple3') && (_p31._0._2.ctor === '::')) {
+				var context = _user$project$Compiler$moduleStatement(_p31._0._2._0);
 				return A3(
 					_elm_lang$core$Basics$flip,
 					F2(
@@ -13345,13 +13352,13 @@ var _user$project$Compiler$tree = function (m) {
 									function (a) {
 										return A2(_user$project$Compiler$elixirS, a, context);
 									},
-									_p30._0._2._1)))));
+									_p31._0._2._1)))));
 			} else {
 				break _v22_2;
 			}
 		} else {
-			if ((((_p30._0.ctor === '_Tuple3') && (_p30._0._0.ctor === '_Tuple0')) && (_p30._0._2.ctor === '::')) && (_p30._0._2._1.ctor === '[]')) {
-				return A2(_elm_lang$core$Basics_ops['++'], ']ERR> Compilation error at: ', _p30._0._1.input);
+			if ((((_p31._0.ctor === '_Tuple3') && (_p31._0._0.ctor === '_Tuple0')) && (_p31._0._2.ctor === '::')) && (_p31._0._2._1.ctor === '[]')) {
+				return A2(_elm_lang$core$Basics_ops['++'], ']ERR> Compilation error at: ', _p31._0._1.input);
 			} else {
 				break _v22_2;
 			}
@@ -13360,11 +13367,11 @@ var _user$project$Compiler$tree = function (m) {
 	return _elm_lang$core$Native_Utils.crashCase(
 		'Compiler',
 		{
-			start: {line: 238, column: 5},
-			end: {line: 251, column: 39}
+			start: {line: 242, column: 5},
+			end: {line: 255, column: 39}
 		},
-		_p30)(
-		_elm_lang$core$Basics$toString(_p30));
+		_p31)(
+		_elm_lang$core$Basics$toString(_p31));
 };
 var _user$project$Main$update = F2(
 	function (action, model) {
@@ -13375,7 +13382,7 @@ var _user$project$Main$update = F2(
 			return '';
 		}
 	});
-var _user$project$Main$init = 'module Main exposing (..)\nimport Elixir.Glue exposing (..)\n\nf : Int -> Int\nf x = x + 1\n\ntupleAdd : (number, number) -> number\ntupleAdd tuple = first tuple + second tuple\n\nadd : number -> number -> number\nadd a b = a + Just b\n\nh = wende g + hajto cichocinski 10\n\ncasa t =\n    case t of\n        wende -> 1\n        cichocinski ->\n            \\a -> 1 + 2\n-- If you alias a record, you can use the name as a constructor function.\notherOrigin : Point3D\notherOrigin =\n  Point3D 0 0 0\n\n\ntype T = Int | String\n\ntest : Int -> String\ntest num =\n    case num of\n        1 -> \"cichocinski\"\n        number -> (\"wende\", number)\n\n';
+var _user$project$Main$init = 'module Main exposing (..)\nimport Elixir.Glue exposing (..)\n\nf : Int -> Int\nf x = x + 1\n\ntupleAdd : (number, number) -> number\ntupleAdd tuple = first tuple + second tuple\n\nadd : number -> number -> number\nadd a b = a + Just b\n\nh = wende g + hajto cichocinski 10\n\ncasa t =\n    case t of\n        wende -> 1\n        cichocinski ->\n            \\a -> 1 + 2\n-- If you alias a record, you can use the name as a constructor function.\notherOrigin : Point3D\notherOrigin =\n  Point3D 0 0 0\n\n\ntype T = Int | String\n\ntest : Int -> String\ntest num =\n    case num of\n        1 -> \"cichocinski\"\n        number -> (\"wende\", number)\n\nadd a b =\n    case a of\n        1 -> a\n        _ -> b\n\n';
 var _user$project$Main$codeStyle = _elm_lang$html$Html_Attributes$style(
 	{
 		ctor: '::',

--- a/index.html
+++ b/index.html
@@ -12414,8 +12414,8 @@ var _user$project$Compiler$getVariableName = function (e) {
 		return _elm_lang$core$Native_Utils.crashCase(
 			'Compiler',
 			{
-				start: {line: 348, column: 5},
-				end: {line: 350, column: 35}
+				start: {line: 357, column: 5},
+				end: {line: 359, column: 35}
 			},
 			_p0)('jeb');
 	}
@@ -12424,8 +12424,8 @@ var _user$project$Compiler$notImplemented = function (value) {
 	return _elm_lang$core$Native_Utils.crash(
 		'Compiler',
 		{
-			start: {line: 344, column: 5},
-			end: {line: 344, column: 16}
+			start: {line: 353, column: 5},
+			end: {line: 353, column: 16}
 		})(
 		A2(
 			_elm_lang$core$Basics_ops['++'],
@@ -12511,8 +12511,8 @@ var _user$project$Compiler$defOrDefp = F2(
 				return _elm_lang$core$Native_Utils.crashCase(
 					'Compiler',
 					{
-						start: {line: 131, column: 5},
-						end: {line: 139, column: 41}
+						start: {line: 140, column: 5},
+						end: {line: 148, column: 41}
 					},
 					_p3)('No such export');
 		}
@@ -12879,8 +12879,8 @@ var _user$project$Compiler$tupleOrFunction = F2(
 		return _elm_lang$core$Native_Utils.crashCase(
 			'Compiler',
 			{
-				start: {line: 294, column: 5},
-				end: {line: 319, column: 75}
+				start: {line: 303, column: 5},
+				end: {line: 328, column: 75}
 			},
 			_p17)(
 			A2(
@@ -12912,8 +12912,8 @@ var _user$project$Compiler$combineComas = function (e) {
 		return _elm_lang$core$Native_Utils.crashCase(
 			'Compiler',
 			{
-				start: {line: 354, column: 5},
-				end: {line: 359, column: 46}
+				start: {line: 363, column: 5},
+				end: {line: 368, column: 46}
 			},
 			_p19)(
 			_elm_lang$core$Basics$toString(_p19));
@@ -13169,6 +13169,37 @@ var _user$project$Compiler$lambda = F3(
 			return A2(_user$project$Compiler$elixirE, body, i);
 		}
 	});
+var _user$project$Compiler$genElixirFunc = F4(
+	function (c, name, args, body) {
+		return A2(
+			_elm_lang$core$Basics_ops['++'],
+			_user$project$Compiler$ind(c.indent),
+			A2(
+				_elm_lang$core$Basics_ops['++'],
+				A2(_user$project$Compiler$defOrDefp, c, name),
+				A2(
+					_elm_lang$core$Basics_ops['++'],
+					name,
+					A2(
+						_elm_lang$core$Basics_ops['++'],
+						'(',
+						A2(
+							_elm_lang$core$Basics_ops['++'],
+							A2(_elm_lang$core$String$join, ',', args),
+							A2(
+								_elm_lang$core$Basics_ops['++'],
+								') do',
+								A2(
+									_elm_lang$core$Basics_ops['++'],
+									_user$project$Compiler$ind(c.indent + 1),
+									A2(
+										_elm_lang$core$Basics_ops['++'],
+										A2(_user$project$Compiler$elixirE, body, c.indent + 1),
+										A2(
+											_elm_lang$core$Basics_ops['++'],
+											_user$project$Compiler$ind(c.indent),
+											'end\n')))))))));
+	});
 var _user$project$Compiler$elixirS = F2(
 	function (s, c) {
 		var _p24 = s;
@@ -13206,35 +13237,36 @@ var _user$project$Compiler$elixirS = F2(
 								_p24._0,
 								_user$project$Compiler$typespec(_p24._1))));
 				case 'FunctionDeclaration':
-					var _p25 = _p24._0;
-					return A2(
-						_elm_lang$core$Basics_ops['++'],
-						_user$project$Compiler$ind(c.indent),
-						A2(
-							_elm_lang$core$Basics_ops['++'],
-							A2(_user$project$Compiler$defOrDefp, c, _p25),
+					var _p29 = _p24._0;
+					var _p28 = _p24._2;
+					var _p25 = _p28;
+					if (_p25.ctor === 'Case') {
+						return A3(
+							_elm_lang$core$List$foldr,
+							F2(
+								function (x, y) {
+									return A2(_elm_lang$core$Basics_ops['++'], x, y);
+								}),
+							'',
 							A2(
-								_elm_lang$core$Basics_ops['++'],
-								_p25,
-								A2(
-									_elm_lang$core$Basics_ops['++'],
-									'(',
-									A2(
-										_elm_lang$core$Basics_ops['++'],
-										A2(_elm_lang$core$String$join, ',', _p24._1),
-										A2(
-											_elm_lang$core$Basics_ops['++'],
-											') do',
-											A2(
-												_elm_lang$core$Basics_ops['++'],
-												_user$project$Compiler$ind(c.indent + 1),
-												A2(
-													_elm_lang$core$Basics_ops['++'],
-													A2(_user$project$Compiler$elixirE, _p24._2, c.indent + 1),
-													A2(
-														_elm_lang$core$Basics_ops['++'],
-														_user$project$Compiler$ind(c.indent),
-														'end\n')))))))));
+								_elm_lang$core$List$map,
+								function (_p26) {
+									var _p27 = _p26;
+									return A4(
+										_user$project$Compiler$genElixirFunc,
+										c,
+										_p29,
+										{
+											ctor: '::',
+											_0: A2(_user$project$Compiler$elixirE, _p27._0, c.indent),
+											_1: {ctor: '[]'}
+										},
+										_p27._1);
+								},
+								A2(_elm_lang$core$Debug$log, 'expression', _p25._1)));
+					} else {
+						return A4(_user$project$Compiler$genElixirFunc, c, _p29, _p24._1, _p28);
+					}
 				case 'Comment':
 					return A2(
 						_elm_lang$core$Basics_ops['++'],
@@ -13273,12 +13305,12 @@ var _user$project$Compiler$elixirS = F2(
 		return _user$project$Compiler$notImplemented(_p24);
 	});
 var _user$project$Compiler$tree = function (m) {
-	var _p26 = _brainrape$elm_ast$Ast$parse(m);
-	_v20_2:
+	var _p30 = _brainrape$elm_ast$Ast$parse(m);
+	_v22_2:
 	do {
-		if (_p26.ctor === 'Ok') {
-			if ((_p26._0.ctor === '_Tuple3') && (_p26._0._2.ctor === '::')) {
-				var context = _user$project$Compiler$moduleStatement(_p26._0._2._0);
+		if (_p30.ctor === 'Ok') {
+			if ((_p30._0.ctor === '_Tuple3') && (_p30._0._2.ctor === '::')) {
+				var context = _user$project$Compiler$moduleStatement(_p30._0._2._0);
 				return A3(
 					_elm_lang$core$Basics$flip,
 					F2(
@@ -13313,26 +13345,26 @@ var _user$project$Compiler$tree = function (m) {
 									function (a) {
 										return A2(_user$project$Compiler$elixirS, a, context);
 									},
-									_p26._0._2._1)))));
+									_p30._0._2._1)))));
 			} else {
-				break _v20_2;
+				break _v22_2;
 			}
 		} else {
-			if ((((_p26._0.ctor === '_Tuple3') && (_p26._0._0.ctor === '_Tuple0')) && (_p26._0._2.ctor === '::')) && (_p26._0._2._1.ctor === '[]')) {
-				return A2(_elm_lang$core$Basics_ops['++'], ']ERR> Compilation error at: ', _p26._0._1.input);
+			if ((((_p30._0.ctor === '_Tuple3') && (_p30._0._0.ctor === '_Tuple0')) && (_p30._0._2.ctor === '::')) && (_p30._0._2._1.ctor === '[]')) {
+				return A2(_elm_lang$core$Basics_ops['++'], ']ERR> Compilation error at: ', _p30._0._1.input);
 			} else {
-				break _v20_2;
+				break _v22_2;
 			}
 		}
 	} while(false);
 	return _elm_lang$core$Native_Utils.crashCase(
 		'Compiler',
 		{
-			start: {line: 229, column: 5},
-			end: {line: 242, column: 39}
+			start: {line: 238, column: 5},
+			end: {line: 251, column: 39}
 		},
-		_p26)(
-		_elm_lang$core$Basics$toString(_p26));
+		_p30)(
+		_elm_lang$core$Basics$toString(_p30));
 };
 var _user$project$Main$update = F2(
 	function (action, model) {
@@ -13343,7 +13375,7 @@ var _user$project$Main$update = F2(
 			return '';
 		}
 	});
-var _user$project$Main$init = 'module Main exposing (..)\nimport Elixir.Glue exposing (..)\n\nf : Int -> Int\nf x = x + 1\n\ntupleAdd : (number, number) -> number\ntupleAdd = first number + second number\n\nadd : number -> number -> number\nadd a b = a + Just b\n\nh = wende g + hajto cichocinski 10\n\ncasa t =\n    case t of\n        wende -> 1\n        cichocinski ->\n            \\a -> 1 + 2\n-- If you alias a record, you can use the name as a constructor function.\notherOrigin : Point3D\notherOrigin =\n  Point3D 0 0 0\n\n\ntype T = Int | String\n';
+var _user$project$Main$init = 'module Main exposing (..)\nimport Elixir.Glue exposing (..)\n\nf : Int -> Int\nf x = x + 1\n\ntupleAdd : (number, number) -> number\ntupleAdd tuple = first tuple + second tuple\n\nadd : number -> number -> number\nadd a b = a + Just b\n\nh = wende g + hajto cichocinski 10\n\ncasa t =\n    case t of\n        wende -> 1\n        cichocinski ->\n            \\a -> 1 + 2\n-- If you alias a record, you can use the name as a constructor function.\notherOrigin : Point3D\notherOrigin =\n  Point3D 0 0 0\n\n\ntype T = Int | String\n\ntest : Int -> String\ntest num =\n    case num of\n        1 -> \"cichocinski\"\n        number -> (\"wende\", number)\n\n';
 var _user$project$Main$codeStyle = _elm_lang$html$Html_Attributes$style(
 	{
 		ctor: '::',

--- a/src/Compiler.elm
+++ b/src/Compiler.elm
@@ -119,13 +119,16 @@ elixirS s c =
         FunctionTypeDeclaration name t ->
             (ind c.indent) ++ "@spec " ++ name ++ (typespec t)
         FunctionDeclaration name args body as fd ->
-            case body of
-                Case _ expressions ->
-                    expressions
-                        |> List.map (\(left, right) -> genElixirFunc c name [elixirE left c.indent] right)
-                        |> List.foldr (++) ""
-                _ ->
-                    genElixirFunc c name args body
+            if List.length args > 1 then
+                genElixirFunc c name args body
+            else
+                case body of
+                    Case _ expressions ->
+                        expressions
+                            |> List.map (\(left, right) -> genElixirFunc c name [elixirE left c.indent] right)
+                            |> List.foldr (++) ""
+                    _ ->
+                        genElixirFunc c name args body
         Comment content ->
             (ind c.indent) ++ "#" ++ content
         -- That's not a real import. In elixir it's called alias


### PR DESCRIPTION
Attempt to resolve #3. Right now it compiles to full function (not `do:` macro), but it think it's good starting point.

```elm
test : Int -> String
test num =
    case num of
        1 -> "cichocinski"
        number -> ("wende", number)
```

```elixir
@spec test(int) :: String.t
def test(1) do
  "cichocinski"
end

def test(number) do
  {"wende", number} 
end
```

EDIT: I know that function is invalid in terms of static type checking but it was done on purpose.