### PR TITLE
Fix extraction from case to function overload

### DIFF
--- a/src/ExStatement.elm
+++ b/src/ExStatement.elm
@@ -49,7 +49,7 @@ elixirS s c =
                     ++ "\n"
             else
                 case body of
-                    Case _ expressions ->
+                    Case (Variable _) expressions ->
                         ExExpression.genOverloadedFunctionDefinition
                             c
                             name


### PR DESCRIPTION
Fixes: #22 
Case extraction to function overload is done properly right now: 
### Elm
```elm
a b = 
  case lol b of
    _ -> 2

c z =
  case z of
    2 -> 1
    a -> a
```

### Elixir
```elixir
curry a/1
def a(b) do
  case lol.(b) do
    _ -> 2
  end
end

curry c/1
def c(2) do
  1
end
def c(a) do
  a
end
```