### PR TITLE
Fix toSnakeCase helper function

### DIFF
--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -23,11 +23,11 @@ notImplemented feature value =
 
 
 toSnakeCase : String -> String
-toSnakeCase var =
-    if String.toUpper var == var then
-        String.toLower var
+toSnakeCase string =
+    if String.toUpper string == string then
+        String.toLower string
     else
-        var
+        string
             |> Regex.split Regex.All (Regex.regex "(?=[A-Z])")
             |> String.join "_"
             |> String.toLower

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -24,17 +24,13 @@ notImplemented feature value =
 
 toSnakeCase : String -> String
 toSnakeCase var =
-    let
-        split =
-            Regex.regex "(?=[A-Z])"
-    in
-        if String.toUpper var == var then
-            String.toLower var
-        else
-            var
-                |> Regex.split Regex.All split
-                |> String.join "_"
-                |> String.toLower
+    if String.toUpper var == var then
+        String.toLower var
+    else
+        var
+            |> Regex.split Regex.All (Regex.regex "(?=[A-Z])")
+            |> String.join "_"
+            |> String.toLower
 
 
 isUpper : String -> Bool

--- a/src/Helpers.elm
+++ b/src/Helpers.elm
@@ -3,6 +3,7 @@ module Helpers exposing (..)
 import Char
 import Tuple exposing (..)
 import List exposing (..)
+import Regex
 
 
 type MaybeUpper
@@ -22,32 +23,18 @@ notImplemented feature value =
 
 
 toSnakeCase : String -> String
-toSnakeCase s =
+toSnakeCase var =
     let
-        res =
-            toSnakeCase_ s
+        split =
+            Regex.regex "(?=[A-Z])"
     in
-        if String.startsWith "_" res && res /= "_" then
-            res |> String.dropLeft 1
+        if String.toUpper var == var then
+            String.toLower var
         else
-            res
-
-
-toSnakeCase_ : String -> String
-toSnakeCase_ e =
-    let
-        withUpper =
-            \a -> ( first a |> Char.isUpper, first a, second a )
-    in
-        case String.uncons e |> Maybe.map withUpper of
-            Just ( True, a, rest ) ->
-                "_" ++ String.cons (Char.toLower a) (toSnakeCase_ rest)
-
-            Just ( False, a, rest ) ->
-                String.cons a (toSnakeCase_ rest)
-
-            Nothing ->
-                ""
+            var
+                |> Regex.split Regex.All split
+                |> String.join "_"
+                |> String.toLower
 
 
 isUpper : String -> Bool


### PR DESCRIPTION
Fixes (#33) `toSnakeCase` function so
```elm
myFunction
MyComplexType
GT
```
becomes
```elixir
my_function
my_complex_type
gt
```